### PR TITLE
Fix TS error on Object.entries

### DIFF
--- a/src/bases/Components/common.ts
+++ b/src/bases/Components/common.ts
@@ -13,12 +13,12 @@ interface FixedCustomIdOption {
 export type ConstructorDataType<T> = DistributiveOmit<T, 'type' | 'custom_id'> &
   (T extends { custom_id?: string } ? FixedCustomIdOption : object);
 
-export interface FrameType<T> {
+export interface FrameType<T extends object> {
   idGen: IDGen;
   componentStore: StoreAdapter<T>;
 }
 
-interface CreateDataArgs<T, U> {
+interface CreateDataArgs<T, U extends object> {
   self: U;
   data: ConstructorDataType<T>;
   Builder: { new (data: Partial<T>): { toJSON(): T } };
@@ -26,7 +26,7 @@ interface CreateDataArgs<T, U> {
   omitCustomId?: boolean;
 }
 
-export function createData<T, U>({
+export function createData<T, U extends object>({
   self,
   data,
   Builder,

--- a/src/store/adapter.test.ts
+++ b/src/store/adapter.test.ts
@@ -86,7 +86,7 @@ describe('StoreAdapter', () => {
     expect(fn).toBeCalled();
   });
 
-  it('throws when class keys are duplicate', () => {
+  it('throws when class keys are duplicated', () => {
     class Base {}
     expect(
       () =>

--- a/src/store/adapter.ts
+++ b/src/store/adapter.ts
@@ -27,7 +27,7 @@ export interface ClassType<T> {
   deserialize?(serialized: JsonObject): T;
 }
 
-export default class StoreAdapter<T> {
+export default class StoreAdapter<T extends object> {
   cache: Collection<string, T> = new Collection();
   classes: Collection<string, ClassType<T>>;
 


### PR DESCRIPTION
```
src/store/adapter.ts:98:26 - error TS2769: No overload matches this call.
  Overload 1 of 2, '(o: { [s: string]: unknown; } | ArrayLike<unknown>): [string, unknown][]', gave the following error.
    Argument of type 'T' is not assignable to parameter of type '{ [s: string]: unknown; } | ArrayLike<unknown>'.
      Type 'T' is not assignable to type 'ArrayLike<unknown>'.
  Overload 2 of 2, '(o: {}): [string, any][]', gave the following error.
    Argument of type 'T' is not assignable to parameter of type '{}'.

98           Object.entries(instance).map(([key, value]) => [
```